### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -17,33 +17,6 @@ import (
 	"github.com/uptrace/bun"
 )
 
-
-// getAllowedFields returns a set of allowed field names for the model type T.
-func getAllowedFields[T any]() map[string]struct{} {
-	var allowed = make(map[string]struct{})
-	var t T
-	typ := reflect.TypeOf(t)
-	// If T is a pointer, get the element type
-	if typ.Kind() == reflect.Ptr {
-		typ = typ.Elem()
-	}
-	if typ.Kind() == reflect.Struct {
-		for i := 0; i < typ.NumField(); i++ {
-			field := typ.Field(i)
-			// Use the bun tag if present, otherwise the struct field name
-			col := field.Tag.Get("bun")
-			if col == "" || col == "-" {
-				col = field.Name
-			} else {
-				// bun tag may have options, take only the column name
-				col = strings.Split(col, ",")[0]
-			}
-			allowed[col] = struct{}{}
-		}
-	}
-	return allowed
-}
-
 func ListAction[T interface{}](postFindFuncs ...func(*gin.Context, *[]T)) func(c *gin.Context) {
 	return func(c *gin.Context) {
 
@@ -62,7 +35,7 @@ func ListAction[T interface{}](postFindFuncs ...func(*gin.Context, *[]T)) func(c
 
 		fields := c.Query("fields")
 		if fields != "" {
-			allowedFields := getAllowedFields[T]()
+			allowedFields := models.GetModelFields[T]()
 			requestedFields := strings.Split(fields, ",")
 			validFields := make([]string, 0, len(requestedFields))
 			for _, f := range requestedFields {

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -17,6 +17,33 @@ import (
 	"github.com/uptrace/bun"
 )
 
+
+// getAllowedFields returns a set of allowed field names for the model type T.
+func getAllowedFields[T any]() map[string]struct{} {
+	var allowed = make(map[string]struct{})
+	var t T
+	typ := reflect.TypeOf(t)
+	// If T is a pointer, get the element type
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if typ.Kind() == reflect.Struct {
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			// Use the bun tag if present, otherwise the struct field name
+			col := field.Tag.Get("bun")
+			if col == "" || col == "-" {
+				col = field.Name
+			} else {
+				// bun tag may have options, take only the column name
+				col = strings.Split(col, ",")[0]
+			}
+			allowed[col] = struct{}{}
+		}
+	}
+	return allowed
+}
+
 func ListAction[T interface{}](postFindFuncs ...func(*gin.Context, *[]T)) func(c *gin.Context) {
 	return func(c *gin.Context) {
 
@@ -35,7 +62,18 @@ func ListAction[T interface{}](postFindFuncs ...func(*gin.Context, *[]T)) func(c
 
 		fields := c.Query("fields")
 		if fields != "" {
-			query = query.ColumnExpr(fields)
+			allowedFields := getAllowedFields[T]()
+			requestedFields := strings.Split(fields, ",")
+			validFields := make([]string, 0, len(requestedFields))
+			for _, f := range requestedFields {
+				f = strings.TrimSpace(f)
+				if _, ok := allowedFields[f]; ok {
+					validFields = append(validFields, f)
+				}
+			}
+			if len(validFields) > 0 {
+				query = query.Column(validFields...)
+			}
 		}
 
 		sort := c.Query("sort")


### PR DESCRIPTION
Potential fix for [https://github.com/iteais/sdk/security/code-scanning/2](https://github.com/iteais/sdk/security/code-scanning/2)

To fix this issue, we need to ensure that only safe, expected column names are used in the `fields` parameter before passing them to `ColumnExpr`. The best way is to validate the user-provided `fields` value against a whitelist of allowed column names for the model in question. This can be done by splitting the `fields` string on commas, trimming whitespace, and checking each field against a set of allowed column names. Only the validated fields should be joined and passed to `ColumnExpr`. If none are valid, we can either skip the `ColumnExpr` call or return an error.

The changes should be made in the `ListAction` function in `pkg/controller.go`, specifically in the block that handles the `fields` parameter (lines 36-39). We will need to:
- Define a set of allowed column names for the model type `T`. Since `T` is generic, we can use reflection to get the struct fields, or require a helper function to provide allowed fields for each model.
- Parse and validate the `fields` parameter.
- Only pass the validated fields to `ColumnExpr`.

We may need to add a helper function to get the allowed fields for a given model type using reflection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
