### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: PHP Composer
+permissions:
+  contents: read
 
 on:
   push:
@@ -25,6 +27,8 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Potential fix for [https://github.com/iteais/sdk/security/code-scanning/5](https://github.com/iteais/sdk/security/code-scanning/5)

To fix this problem, you should add an explicit `permissions` block to the workflow. The optimal approach is to place it at the root level of the workflow, so it applies to all jobs unless overridden. For this workflow, the `release` job uses the `softprops/action-gh-release` action, which needs `contents: write` to create GitHub releases. The `build` job only checks out code, sets up Go, installs dependencies, and runs tests, which only require `contents: read`. Therefore, you can add the following at the root of the workflow:
```yaml
permissions:
  contents: read
```
Then, for the `release` job, override the `permissions` block to grant `contents: write`, as that's required for the GitHub Release step:
```yaml
permissions:
  contents: write
```

You should:
- Insert a `permissions: contents: read` block after the workflow name at the very top.
- Insert a per-job override in the `release` job to use `contents: write`.

No changes are required to other keys or imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
